### PR TITLE
fix: support new player UI

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "Roll Together",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"description": "Synchronize Crunchyroll Videos",
 	"background": {
 		"service_worker": "service_worker.js",
@@ -10,6 +10,7 @@
 		{
 			"all_frames": true,
 			"matches": [
+				"*://www.crunchyroll.com/*",
 				"*://static.crunchyroll.com/*"
 			],
 			"js": [

--- a/src/content_script.ts
+++ b/src/content_script.ts
@@ -145,7 +145,7 @@ function handleServiceWorkerMessage(serviceWorkerMessage: Message) {
 }
 
 function runContentScript() {
-  g_player = document.getElementById("player0") as HTMLVideoElement;
+  g_player = (document.getElementById("player0") || document.getElementById("bitmovinplayer-video-null")) as HTMLVideoElement;
 
   if (!g_player) {
     setTimeout(runContentScript, 500);


### PR DESCRIPTION
Adds support for the new player UI by adjusting the video element to find on the site and allowing the `content_script.ts` to run on the main `www.crunchyroll.com` domain.

closes #38 